### PR TITLE
Doc: replace teamtalk to pytalk for events

### DIFF
--- a/docs/_static/csv/bot.csv
+++ b/docs/_static/csv/bot.csv
@@ -1,7 +1,7 @@
-on_message	teamtalk.Message (either teamtalk.ChannelMessage, teamtalk.DirectMessage, teamtalk.BroadcastMessage)	Called when the bot receives a message.
-on_my_connect	teamtalk.Server	Called when the bot has successfully connected to the teamtalk.Server
-on_my_login	teamtalk.Server	Called when the bot has successfully logged in to the teamtalk.Server
-on_my_logout	teamtalk.Server	Called when the bot has successfully logged out from the teamtalk.Server
-on_my_disconnec	teamtalk.Server	Called when the bot has successfully disconnected from the teamtalk.Server
-on_my_connection_lost	teamtalk.instance	Called when the bot has lost connection to the teamtalk.Server
-on_my_kicked_from_channel	teamtalk.Channel	Called when the bot has been kicked from teamtalk.Channel
+on_message	pytalk.Message (either pytalk.ChannelMessage, pytalk.DirectMessage, pytalk.BroadcastMessage)	Called when the bot receives a message.
+on_my_connect	pytalk.Server	Called when the bot has successfully connected to the pytalk.Server
+on_my_login	pytalk.Server	Called when the bot has successfully logged in to the pytalk.Server
+on_my_logout	pytalk.Server	Called when the bot has successfully logged out from the pytalk.Server
+on_my_disconnec	pytalk.Server	Called when the bot has successfully disconnected from the pytalk.Server
+on_my_connection_lost	pytalk.instance	Called when the bot has lost connection to the pytalk.Server
+on_my_kicked_from_channel	pytalk.Channel	Called when the bot has been kicked from pytalk.Channel

--- a/docs/_static/csv/server_channel_n_file.csv
+++ b/docs/_static/csv/server_channel_n_file.csv
@@ -1,9 +1,9 @@
-on_channel_new	teamtalk.Channel	Called when a new channel (teamtalk.Channel) is created.
-on_channel_update	teamtalk.Channel	Called when a teamtalk.Channel has been updated.
-on_channel_delete	teamtalk.Channel	Called when a teamtalk.Channel has been deleted from the server.
-on_server_update	teamtalk.Server	Called when a teamtalk.Server has updated its settings.
-on_server_statistics	teamtalk.Statistics	Called when a TeamTalk server sends it's statistics.
-on_file_new	teamtalk.RemoteFile	Called when a file has been uploaded to a channel.
-on_file_delete	teamtalk.RemoteFile	Called when a file has been deleted from a channel.
-on_muxed_audio	teamtalk.MuxedAudioBlock	called when a muxed audio block is recieved, this is used to get audio from all users in the channel at once.
-on_user_audio	teamtalk.AudioBlock	called when an audio block is recieved from a user, this is the audio for an individual user, not the hole server.
+on_channel_new	pytalk.Channel	Called when a new channel (pytalk.Channel) is created.
+on_channel_update	pytalk.Channel	Called when a pytalk.Channel has been updated.
+on_channel_delete	pytalk.Channel	Called when a pytalk.Channel has been deleted from the server.
+on_server_update	pytalk.Server	Called when a pytalk.Server has updated its settings.
+on_server_statistics	pytalk.Statistics	Called when a TeamTalk server sends it's statistics.
+on_file_new	pytalk.RemoteFile	Called when a file has been uploaded to a channel.
+on_file_delete	pytalk.RemoteFile	Called when a file has been deleted from a channel.
+on_muxed_audio	pytalk.MuxedAudioBlock	called when a muxed audio block is recieved, this is used to get audio from all users in the channel at once.
+on_user_audio	pytalk.AudioBlock	called when an audio block is recieved from a user, this is the audio for an individual user, not the hole server.

--- a/docs/_static/csv/user.csv
+++ b/docs/_static/csv/user.csv
@@ -1,6 +1,6 @@
-on_user_audio	teamtalk.AudioBlock	Called when a user transmits audio.
-on_user_login	teamtalk.user	Called when a user logs in to a server that the bot is on
-on_user_logout	teamtalk.User	Called when a user logs out from a server that the bot is on
-on_user_update	teamtalk.User	Called when a user gets updated
-on_user_join	teamtalk.User, teamtalk.Channel	Called when a teamtalk.User joins a teamtalk.Channel
-on_user_left	teamtalk.User, teamtalk.Channel	Called when a teamtalk.User leaves a teamtalk.Channel
+on_user_audio	pytalk.AudioBlock	Called when a user transmits audio.
+on_user_login	pytalk.user	Called when a user logs in to a server that the bot is on
+on_user_logout	pytalk.User	Called when a user logs out from a server that the bot is on
+on_user_update	pytalk.User	Called when a user gets updated
+on_user_join	pytalk.User, pytalk.Channel	Called when a pytalk.User joins a pytalk.Channel
+on_user_left	pytalk.User, pytalk.Channel	Called when a pytalk.User leaves a pytalk.Channel

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -5,7 +5,7 @@ This page documents the various events that a TeamTalk Bot can listen to.
 
 The tables are grouped by relevance.
 
-For more information, on what each teamtalk.* function does, please refer to the :doc:`/api` documentation.
+For more information, on what each pytalk.* function does, please refer to the :doc:`/api` documentation.
 
 
 How do I use these events?
@@ -13,7 +13,7 @@ How do I use these events?
 
 The events are listed in the following tables. Each event has a name, a list of arguments that are passed to the event handler and a description of what the event is.
 
-To listen to an event, you must use the :func:`teamtalk.bot.event` decorator.
+To listen to an event, you must use the :func:`pytalk.bot.event` decorator.
 
 
 example:


### PR DESCRIPTION
Documentation is still refering to `teamtalk` instead of `pytalk` for event methods arguments.
